### PR TITLE
#55 | fix: Fix formatting

### DIFF
--- a/composeApp/src/androidMain/kotlin/app/icampuspass/AndroidApp.kt
+++ b/composeApp/src/androidMain/kotlin/app/icampuspass/AndroidApp.kt
@@ -4,7 +4,7 @@ import android.app.Application
 import app.icampuspass.viewmodels.MainViewModel
 import org.koin.dsl.module
 
-class AndroidApp: Application() {
+class AndroidApp : Application() {
     override fun onCreate() {
         super.onCreate()
 

--- a/composeApp/src/androidMain/kotlin/app/icampuspass/App.kt
+++ b/composeApp/src/androidMain/kotlin/app/icampuspass/App.kt
@@ -28,7 +28,7 @@ import org.koin.androidx.compose.koinViewModel
 @Composable
 fun App() {
     MaterialTheme {
-        val viewModel: MainViewModel = koinViewModel<MainViewModel>()
+        val viewModel = koinViewModel<MainViewModel>()
 
         var showContent by remember { mutableStateOf(value = false) }
 

--- a/composeApp/src/androidMain/kotlin/app/icampuspass/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/app/icampuspass/MainActivity.kt
@@ -10,7 +10,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.tooling.preview.Preview
 
-class MainActivity: AppCompatActivity() {
+class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge(
             statusBarStyle = SystemBarStyle.dark(Color.Black.toArgb()),

--- a/shared/src/androidMain/kotlin/app/icampuspass/Koin.android.kt
+++ b/shared/src/androidMain/kotlin/app/icampuspass/Koin.android.kt
@@ -7,7 +7,7 @@ import org.koin.core.context.startKoin
 import org.koin.core.module.Module
 import org.koin.dsl.module
 
-actual val platformModule: Module = module {
+actual val platformModule = module {
     single<DriverFactory> {
         DriverFactory(context = get())
     }

--- a/shared/src/androidMain/kotlin/app/icampuspass/Platform.android.kt
+++ b/shared/src/androidMain/kotlin/app/icampuspass/Platform.android.kt
@@ -2,7 +2,7 @@ package app.icampuspass
 
 import android.os.Build
 
-class AndroidPlatform: Platform {
+class AndroidPlatform : Platform {
     override val name: String = "Android ${Build.VERSION.SDK_INT}"
 }
 

--- a/shared/src/commonMain/kotlin/app/icampuspass/AppRepository.kt
+++ b/shared/src/commonMain/kotlin/app/icampuspass/AppRepository.kt
@@ -5,7 +5,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 
 class AppRepository() {
-    private val scope: CoroutineScope = CoroutineScope(context = SupervisorJob())
+    private val scope = CoroutineScope(context = SupervisorJob())
 
     fun init() {
         scope.launch {}

--- a/shared/src/commonMain/kotlin/app/icampuspass/Koin.kt
+++ b/shared/src/commonMain/kotlin/app/icampuspass/Koin.kt
@@ -1,17 +1,11 @@
 package app.icampuspass
 
 import app.icampuspass.models.database.DatabaseHelper
-import io.ktor.client.HttpClient
-import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
-import io.ktor.client.plugins.cookies.HttpCookies
-import io.ktor.http.ContentType
-import io.ktor.serialization.kotlinx.json.json
-import kotlinx.serialization.json.Json
 import org.koin.core.context.startKoin
 import org.koin.core.module.Module
 import org.koin.dsl.module
 
-val commonModule: Module = module {
+val commonModule = module {
     single<AppRepository> {
         AppRepository().apply {
             init()

--- a/shared/src/commonMain/kotlin/app/icampuspass/models/database/DatabaseHelper.kt
+++ b/shared/src/commonMain/kotlin/app/icampuspass/models/database/DatabaseHelper.kt
@@ -1,7 +1,5 @@
 package app.icampuspass.models.database
 
-import app.cash.sqldelight.db.SqlDriver
-
 class DatabaseHelper(
     private val driverFactory: DriverFactory
 ) {
@@ -11,5 +9,5 @@ class DatabaseHelper(
 
     private val driver = driverFactory.createDriver()
 
-    private val database: Database = Database(driver)
+    private val database = Database(driver)
 }

--- a/shared/src/commonMain/kotlin/app/icampuspass/viewmodels/MainViewModel.kt
+++ b/shared/src/commonMain/kotlin/app/icampuspass/viewmodels/MainViewModel.kt
@@ -5,5 +5,5 @@ import com.rickclephas.kmp.observableviewmodel.ViewModel
 
 class MainViewModel(
     private val appRepository: AppRepository
-): ViewModel() {
+) : ViewModel() {
 }

--- a/shared/src/iosMain/kotlin/app/icampuspass/Koin.ios.kt
+++ b/shared/src/iosMain/kotlin/app/icampuspass/Koin.ios.kt
@@ -1,10 +1,9 @@
 package app.icampuspass
 
 import app.icampuspass.models.database.DriverFactory
-import org.koin.core.module.Module
 import org.koin.dsl.module
 
-actual val platformModule: Module = module {
+actual val platformModule = module {
     single<DriverFactory> {
         DriverFactory()
     }

--- a/shared/src/iosMain/kotlin/app/icampuspass/KoinDependencies.kt
+++ b/shared/src/iosMain/kotlin/app/icampuspass/KoinDependencies.kt
@@ -3,6 +3,6 @@ package app.icampuspass
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
-class KoinDependencies: KoinComponent {
+class KoinDependencies : KoinComponent {
     val appRepository: AppRepository by inject()
 }

--- a/shared/src/iosMain/kotlin/app/icampuspass/Platform.ios.kt
+++ b/shared/src/iosMain/kotlin/app/icampuspass/Platform.ios.kt
@@ -2,8 +2,9 @@ package app.icampuspass
 
 import platform.UIKit.UIDevice
 
-class IOSPlatform: Platform {
-    override val name: String = UIDevice.currentDevice.systemName() + " " + UIDevice.currentDevice.systemVersion
+class IOSPlatform : Platform {
+    override val name: String =
+        UIDevice.currentDevice.systemName() + " " + UIDevice.currentDevice.systemVersion
 }
 
 actual fun getPlatform(): Platform = IOSPlatform()


### PR DESCRIPTION
Put a space before `:` in the following scenarios:

* When it's used to separate a type and a supertype.
* When delegating to a superclass constructor or a different constructor of the same class.
* After the `object` keyword.

https://kotlinlang.org/docs/coding-conventions.html#colon

Change-Id: I4cf1a3dee7f178b9b2b41dd83936854e5cbff7eb